### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://williamblum.visualstudio.com/a50c4097-c9a3-4262-ba54-b517a7c2683d/6816f3cc-1ab5-4743-a4d4-6b7c8428e1a7/_apis/work/boardbadge/38d41e58-c05f-4a9e-b046-7a412cb606b1)](https://williamblum.visualstudio.com/a50c4097-c9a3-4262-ba54-b517a7c2683d/_boards/board/t/6816f3cc-1ab5-4743-a4d4-6b7c8428e1a7/Microsoft.RequirementCategory)
 NppColumnSort
 =============
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://williamblum.visualstudio.com/a50c4097-c9a3-4262-ba54-b517a7c2683d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.